### PR TITLE
Aspnet core sip handler

### DIFF
--- a/SipCs.Tests/SampleSipMessages/Rfc4475TestMessages.cs
+++ b/SipCs.Tests/SampleSipMessages/Rfc4475TestMessages.cs
@@ -47,6 +47,76 @@ a=rtpmap:31 LPC
 ";
 
         /// <summary>
+        /// from RFC 4475
+        /// </summary>
+        public const string AnINVITEWithNoBody =
+            @"INVITE sip:vivekg@chair-dnrc.example.com;unknownparam SIP/2.0
+TO :
+ sip:vivekg@chair-dnrc.example.com ;   tag    = 1918181833n
+from   : ""J Rosenberg \\\""""       <sip:jdrosen@example.com>
+  ;
+  tag = 98asjd8
+MaX-fOrWaRdS: 0068
+Call-ID: wsinv.ndaksdj@192.0.2.1
+Content-Length   : 0
+cseq: 0009
+  INVITE
+Via  : SIP  /   2.0
+ /UDP
+    192.0.2.2;branch=390skdjuw
+s :
+NewFangledHeader:   newfangled value
+ continued newfangled value
+UnknownHeaderWithUnusualValue: ;;,,;;,;
+Content-Type: application/sdp
+Route:
+ <sip:services.example.com;lr;unknownwith=value;unknown-no-value>
+v:  SIP  / 2.0  / TCP     spindle.example.com   ;
+  branch  =   z9hG4bK9ikj8  ,
+ SIP  /    2.0   / UDP  192.168.255.111   ; branch=
+ z9hG4bK30239
+m:""Quoted string \""\"""" <sip:jdrosen@example.com> ; newparam =
+      newvalue ;
+  secondparam ; q = 0.33
+
+";
+
+        /// <summary>
+        /// from RFC 4475
+        /// </summary>
+        public const string AnINVITEWithIncompleteBody =
+            @"INVITE sip:vivekg@chair-dnrc.example.com;unknownparam SIP/2.0
+TO :
+ sip:vivekg@chair-dnrc.example.com ;   tag    = 1918181833n
+from   : ""J Rosenberg \\\""""       <sip:jdrosen@example.com>
+  ;
+  tag = 98asjd8
+MaX-fOrWaRdS: 0068
+Call-ID: wsinv.ndaksdj@192.0.2.1
+Content-Length   : 150
+cseq: 0009
+  INVITE
+Via  : SIP  /   2.0
+ /UDP
+    192.0.2.2;branch=390skdjuw
+s :
+NewFangledHeader:   newfangled value
+ continued newfangled value
+UnknownHeaderWithUnusualValue: ;;,,;;,;
+Content-Type: application/sdp
+Route:
+ <sip:services.example.com;lr;unknownwith=value;unknown-no-value>
+v:  SIP  / 2.0  / TCP     spindle.example.com   ;
+  branch  =   z9hG4bK9ikj8  ,
+ SIP  /    2.0   / UDP  192.168.255.111   ; branch=
+ z9hG4bK30239
+m:""Quoted string \""\"""" <sip:jdrosen@example.com> ; newparam =
+      newvalue ;
+  secondparam ; q = 0.33
+
+";
+
+        /// <summary>
         /// 3.1.1.8.  Extra Trailing Octets in a UDP Datagram
         /// </summary>
         /// <remarks>

--- a/SipCs.Tests/SipCs.Tests.csproj
+++ b/SipCs.Tests/SipCs.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/SipCs.Tests/SipParserTests.cs
+++ b/SipCs.Tests/SipParserTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using SipCs.Headers;
 using SipCs.Tests.SampleSipMessages;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -108,6 +109,67 @@ a=rtpmap:31 LPC
             //User-Agent: Asterisk PBX
             //Max-Forwards: 70
             //Date: Wed, 06 Dec 2009 14:12:45 GMT
+        }
+
+        [Fact]
+        public void ParseBytesForSIPMessageShouldReturnTrueWhenGivenACompleteMessage()
+        {
+            var mock = new Mock<ISipParserHandler>();
+            SipParser parser = new SipParser(mock.Object);
+
+            byte[] messageBytes = Encoding.ASCII.GetBytes(Rfc4475TestMessages.AShortTortuousINVITE);
+
+            bool wasMessageComplete = parser.ParseRequest(messageBytes);
+
+            Assert.True(wasMessageComplete);
+        }
+
+        [Fact]
+        public void ParseBytesForSIPMessageShouldReturnFalseWhenHeaderEndBytesAreMissing()
+        {
+            var mock = new Mock<ISipParserHandler>();
+            SipParser parser = new SipParser(mock.Object);
+
+            byte[] messageBytes = Encoding.ASCII.GetBytes(Rfc4475TestMessages.AShortTortuousINVITE);
+
+            //850 is the final LF
+
+            byte[] messageBytesWithoutHeaderEndBytes = new byte[847];
+
+            Array.Copy(messageBytes, 0, messageBytesWithoutHeaderEndBytes, 0, messageBytesWithoutHeaderEndBytes.Length);
+
+            bool wasMessageComplete = parser.ParseRequest(messageBytesWithoutHeaderEndBytes);
+
+            //Result should be false since we don't have all the header bytes (missing CLRF CLRF)
+            Assert.False(wasMessageComplete);
+        }
+
+        [Fact]
+        public void ParseBytesForSIPMessageShouldReturnTrueForEmptyBody()
+        {
+            var mock = new Mock<ISipParserHandler>();
+            SipParser parser = new SipParser(mock.Object);
+
+            byte[] messageBytes = Encoding.ASCII.GetBytes(Rfc4475TestMessages.AnINVITEWithNoBody);
+
+            bool wasMessageComplete = parser.ParseRequest(messageBytes);
+
+            //Result should be false since we don't have all the header bytes (missing CLRF CLRF)
+            Assert.True(wasMessageComplete);
+        }
+
+        [Fact]
+        public void ParseBytesForSIPMessageShouldReturnFalseForIncompleteBody()
+        {
+            var mock = new Mock<ISipParserHandler>();
+            SipParser parser = new SipParser(mock.Object);
+
+            byte[] messageBytes = Encoding.ASCII.GetBytes(Rfc4475TestMessages.AnINVITEWithIncompleteBody);
+
+            bool wasMessageComplete = parser.ParseRequest(messageBytes);
+
+            //Result should be false since we don't have all the header bytes (missing CLRF CLRF)
+            Assert.False(wasMessageComplete);
         }
     }
 }

--- a/SipCs.Tests/SipTcpConnectionHandlerIntegrationTests.cs
+++ b/SipCs.Tests/SipTcpConnectionHandlerIntegrationTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SipCs.Tests
+{
+    public class SipTcpConnectionHandlerIntegrationTests
+    {
+        [Fact]
+        public async Task Connection_handler_should_parse_sip_bytes_correctly()
+        {
+            //start up a kestrel server
+            //don't await this task because it won't complete until
+            //the server is shutdown
+            var webHostTask = WebHost
+                            .CreateDefaultBuilder()
+                            //.ConfigureKestrel((KestrelServerOptions options) =>
+                            //{
+                            //    options
+                            //    .Listen(new IPEndPoint(IPAddress.Any, 8009), listenOptions =>
+                            //    {
+                            //        listenOptions.UseConnectionHandler<SipTcpConnectionHandler>();
+                            //    });
+                            //})
+                            .ConfigureLogging(logBuilder =>
+                            {
+                                logBuilder.AddConsole();
+                            })
+                            .UseKestrel(options =>
+                            {
+                                options.ListenLocalhost(8007, listenOptions =>
+                                {
+                                    listenOptions.UseConnectionHandler<SipTcpConnectionHandler>();
+                                });
+                            })
+                            .UseStartup<Startup>()
+                            .Build()
+                            .RunAsync();
+
+            //open a TCP connection to it
+            TcpClient tcpClient = new TcpClient();
+
+            byte[] someBytes = new byte[] { 0x01, 0x0c };
+
+            await tcpClient.ConnectAsync(IPAddress.Loopback, 8007);
+
+            var stream = tcpClient.GetStream();
+
+            await stream.WriteAsync(someBytes, 0, someBytes.Length);
+            //Make sure we parsed sip stuff somehow?
+
+            byte[] responseBuffer = new byte[1024];
+
+            var response = await stream.ReadAsync(responseBuffer, 0, responseBuffer.Length);
+
+        }
+
+
+        class Startup
+        {
+            // This method gets called by the runtime. Use this method to add services to the container.
+            // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddLogging(options =>
+                {
+                    options.AddConsole();
+                });
+            }
+
+            // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+            public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+            {
+            }
+        }
+    }
+}

--- a/SipCs.Tests/SipTcpConnectionHandlerIntegrationTests.cs
+++ b/SipCs.Tests/SipTcpConnectionHandlerIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SipCs.Tests.SampleSipMessages;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -51,13 +52,13 @@ namespace SipCs.Tests
             //open a TCP connection to it
             TcpClient tcpClient = new TcpClient();
 
-            byte[] someBytes = new byte[] { 0x01, 0x0c };
+            byte[] messageBytes = Encoding.ASCII.GetBytes(Rfc4475TestMessages.AShortTortuousINVITE);
 
             await tcpClient.ConnectAsync(IPAddress.Loopback, 8007);
 
             var stream = tcpClient.GetStream();
 
-            await stream.WriteAsync(someBytes, 0, someBytes.Length);
+            await stream.WriteAsync(messageBytes, 0, messageBytes.Length);
             //Make sure we parsed sip stuff somehow?
 
             byte[] responseBuffer = new byte[1024];
@@ -77,6 +78,8 @@ namespace SipCs.Tests
                 {
                     options.AddConsole();
                 });
+
+                services.AddSingleton(new SipParser());
             }
 
             // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/SipCs/SipCs.csproj
+++ b/SipCs/SipCs.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/SipCs/SipCs.csproj
+++ b/SipCs/SipCs.csproj
@@ -17,4 +17,8 @@
     
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/SipCs/SipTcpConnectionHandler.cs
+++ b/SipCs/SipTcpConnectionHandler.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Connections;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SipCs
+{
+    public class SipTcpConnectionHandler : ConnectionHandler
+    {
+        public override Task OnConnectedAsync(ConnectionContext connection)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SipCs/SipTcpConnectionHandler.cs
+++ b/SipCs/SipTcpConnectionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -8,9 +9,22 @@ namespace SipCs
 {
     public class SipTcpConnectionHandler : ConnectionHandler
     {
-        public override Task OnConnectedAsync(ConnectionContext connection)
+        private readonly ILogger<SipTcpConnectionHandler> logger;
+
+        public SipTcpConnectionHandler(ILogger<SipTcpConnectionHandler> logger)
         {
-            throw new NotImplementedException();
+            this.logger = logger;
+        }
+
+        public override async Task OnConnectedAsync(ConnectionContext connection)
+        {
+            logger.LogDebug($"Received connection: {connection.ConnectionId}");
+
+            while(true)
+            {
+                var result = await connection.Transport.Input.ReadAsync();
+                var buffer = result.Buffer;
+            }
         }
     }
 }

--- a/SipCs/SipTcpConnectionHandler.cs
+++ b/SipCs/SipTcpConnectionHandler.cs
@@ -10,10 +10,12 @@ namespace SipCs
     public class SipTcpConnectionHandler : ConnectionHandler
     {
         private readonly ILogger<SipTcpConnectionHandler> logger;
+        private readonly SipParser sipParser;
 
-        public SipTcpConnectionHandler(ILogger<SipTcpConnectionHandler> logger)
+        public SipTcpConnectionHandler(ILogger<SipTcpConnectionHandler> logger, SipParser sipParser)
         {
             this.logger = logger;
+            this.sipParser = sipParser;
         }
 
         public override async Task OnConnectedAsync(ConnectionContext connection)
@@ -24,6 +26,10 @@ namespace SipCs
             {
                 var result = await connection.Transport.Input.ReadAsync();
                 var buffer = result.Buffer;
+
+                //sipParser.ParseRequest(buffer);
+
+
             }
         }
     }


### PR DESCRIPTION
#4 

Starting the implementation of the SipTcpConnectionHandler

I had to modify the SipParser's Parse method to fit with the buffer stream paradigm of the ConnectionHandler class.

It now returns true/false based on whether it's been given a buffer containing a complete SIP message (complete here meaning the CRLF CRLF was received so we have the whole header and body length matches what was sent in content-length)

I'm not quite done yet but I wanted to open the PR so @jeoffman  can see where I'm going.

I have to sign off now but I'm hoping to finish this out tonight/tomorrow.